### PR TITLE
Fixed VirtualPathRoot interfere with default routing problem

### DIFF
--- a/Source/Examples/AspNetCore31/Pages/Shared/_Layout.cshtml
+++ b/Source/Examples/AspNetCore31/Pages/Shared/_Layout.cshtml
@@ -22,7 +22,7 @@
                             <a class="nav-link text-dark" asp-area="" asp-page="/Index">Home</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link text-dark"   href= "/Quartzmin">Quartzmin</a>
+                            <a class="nav-link text-dark"   href= "/Quartzmin/Scheduler">Quartzmin</a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-page="/Privacy">Privacy</a>

--- a/Source/Examples/AspNetCore31/Startup.cs
+++ b/Source/Examples/AspNetCore31/Startup.cs
@@ -42,11 +42,12 @@ namespace AspNetCore31
             var scheduler = DemoScheduler.Create().Result;
         
             app.UseStaticFiles();
+            app.UseQuartzmin(new QuartzminOptions() { Scheduler = scheduler, VirtualPathRoot = "/Quartzmin" , UseLocalTime =true, DefaultDateFormat="yyyy-MM-dd", DefaultTimeFormat="HH:mm:ss" });
             app.UseRouting();
             app.UseAuthorization();
-            app.UseQuartzmin(new QuartzminOptions() { Scheduler = scheduler, VirtualPathRoot = "/Quartzmin" , UseLocalTime =true, DefaultDateFormat="yyyy-MM-dd", DefaultTimeFormat="HH:mm:ss" });
             app.UseEndpoints(endpoints =>
             {
+                endpoints.MapDefaultControllerRoute();
                 endpoints.MapRazorPages();
             });
      

--- a/Source/Quartzmin/ApplicationBuilderExtensions.cs
+++ b/Source/Quartzmin/ApplicationBuilderExtensions.cs
@@ -28,12 +28,22 @@ namespace Quartzmin
                  await next.Invoke();
              } );
 
-       
 #if NETCOREAPP
-            app.UseEndpoints( endpoints =>
+            app.Use(async (context,next) =>
             {
-                endpoints.MapControllerRoute( nameof( Quartzmin ), $"{options.VirtualPathRoot}/{{controller=Scheduler}}/{{action=Index}}" );
-            } );
+                var url = context.Request.Path.Value;
+
+                // Redirect to an external URL
+                if (!string.IsNullOrWhiteSpace(options.VirtualPathRoot) && options.VirtualPathRoot!="/" && options.VirtualPathRoot!=$"/Quartzmin" && url.Contains($"{options.VirtualPathRoot}"))
+                {
+                     context.Request.Path = url.Replace($"{options.VirtualPathRoot}",($"{options.VirtualPathRoot}".StartsWith("/")?"/":"")+$"Quartzmin"+($"{options.VirtualPathRoot}".EndsWith("/")?"/":""));
+                }
+                await next();
+            });
+            //app.UseEndpoints( endpoints =>
+            //{
+            //    endpoints.MapControllerRoute( nameof( Quartzmin ),pattern:$"{options.VirtualPathRoot}/", $"{options.VirtualPathRoot}/{{controller=Scheduler}}/{{action=Index}}" );
+            //} );
 #else
             app.UseMvc( routes =>
             {

--- a/Source/Quartzmin/Controllers/CalendarsController.cs
+++ b/Source/Quartzmin/Controllers/CalendarsController.cs
@@ -18,8 +18,10 @@ using IActionResult = System.Web.Http.IHttpActionResult;
 
 namespace Quartzmin.Controllers
 {
+    [Route("Quartzmin/[controller]/[action]")]
     public class CalendarsController : PageControllerBase
     {
+        [Route("/Quartzmin/[controller]")]
         [HttpGet]
         public async Task<IActionResult> Index()
         {

--- a/Source/Quartzmin/Controllers/ExecutionsController.cs
+++ b/Source/Quartzmin/Controllers/ExecutionsController.cs
@@ -20,8 +20,10 @@ using IActionResult = System.Web.Http.IHttpActionResult;
 
 namespace Quartzmin.Controllers
 {
+    [Route("Quartzmin/[controller]/[action]")]
     public class ExecutionsController : PageControllerBase
     {
+        [Route("/Quartzmin/[controller]")]
         [HttpGet]
         public async Task<IActionResult> Index()
         {

--- a/Source/Quartzmin/Controllers/HistoryController.cs
+++ b/Source/Quartzmin/Controllers/HistoryController.cs
@@ -16,8 +16,10 @@ using IActionResult = System.Web.Http.IHttpActionResult;
 
 namespace Quartzmin.Controllers
 {
+    [Route("Quartzmin/[controller]/[action]")]
     public class HistoryController : PageControllerBase
     {
+        [Route("/Quartzmin/[controller]")]
         [HttpGet]
         public async Task<IActionResult> Index()
         {

--- a/Source/Quartzmin/Controllers/JobDataMapController.cs
+++ b/Source/Quartzmin/Controllers/JobDataMapController.cs
@@ -22,6 +22,7 @@ using System.Web.Http.Results;
 
 namespace Quartzmin.Controllers
 {
+    [Route("Quartzmin/[controller]/[action]")]
     public class JobDataMapController : PageControllerBase
     {
         [HttpPost, JsonErrorResponse]

--- a/Source/Quartzmin/Controllers/JobsController.cs
+++ b/Source/Quartzmin/Controllers/JobsController.cs
@@ -20,8 +20,10 @@ using IActionResult = System.Web.Http.IHttpActionResult;
 
 namespace Quartzmin.Controllers
 {
+    [Route("Quartzmin/[controller]/[action]")]
     public class JobsController : PageControllerBase
     {
+        [Route("/Quartzmin/[controller]")]
         [HttpGet]
         public async Task<IActionResult> Index()
         {

--- a/Source/Quartzmin/Controllers/SchedulerController.cs
+++ b/Source/Quartzmin/Controllers/SchedulerController.cs
@@ -21,8 +21,10 @@ using IActionResult = System.Web.Http.IHttpActionResult;
 
 namespace Quartzmin.Controllers
 {
+    [Route("Quartzmin/[controller]/[action]")]
     public class SchedulerController : PageControllerBase
     {
+        [Route("/Quartzmin/[controller]")]
         [HttpGet]
         public async Task<IActionResult> Index()
         {

--- a/Source/Quartzmin/Controllers/TriggersController.cs
+++ b/Source/Quartzmin/Controllers/TriggersController.cs
@@ -20,8 +20,10 @@ using IActionResult = System.Web.Http.IHttpActionResult;
 
 namespace Quartzmin.Controllers
 {
+    [Route("Quartzmin/[controller]/[action]")]
     public class TriggersController : PageControllerBase
     {
+        [Route("/Quartzmin/[controller]")]
         [HttpGet]
         public async Task<IActionResult> Index()
         {


### PR DESCRIPTION
VituralPathRoot will interfere with the default route mapping for non-quartzmin controllers.